### PR TITLE
Print number of subjects in each risk set for show method

### DIFF
--- a/R/landmarking.R
+++ b/R/landmarking.R
@@ -161,8 +161,9 @@ setMethod(
           "    Landmark ",
           object@landmarks[i],
           ": ",
-          head(object@risk_sets[[i]], 10),
-          " ...\n"
+          nrow(object@risk_sets[[i]]),
+          " subjects.\n",
+          sep = ""
         )
       }
     }


### PR DESCRIPTION
Rather than giving an example of ten subjects in the risk set, giving the number of subjects seems more informative. 