### PR TITLE
(Hopefully) fix flaky tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,8 @@ Suggests:
     tidyverse,
     spelling,
     joineR,
-    survminer
+    survminer,
+    withr
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 LazyData: true

--- a/tests/testthat/test-landmarking_longitudinal.R
+++ b/tests/testthat/test-landmarking_longitudinal.R
@@ -1,4 +1,5 @@
 initialise_longitudinal_test_ <- function(epileptic, K = 1) {
+  withr::local_seed(123)
   epileptic$dose2 <- as.factor(epileptic$dose > 2)
   epileptic_dfs <- split_wide_df(
     epileptic,

--- a/tests/testthat/test-landmarking_longitudinal.R
+++ b/tests/testthat/test-landmarking_longitudinal.R
@@ -38,6 +38,7 @@ initialise_longitudinal_test_ <- function(epileptic, K = 1) {
 }
 
 test_that("LCMM works as expected", {
+  withr::local_seed(123)
   x <- initialise_longitudinal_test_(epileptic = epileptic)
   x <- x |>
     compute_risk_sets(seq(from = 365.25, to = 5 * 365.25, by = 365.25)) |>
@@ -191,10 +192,10 @@ test_that("LOCF populates test fold predictions when validation_fold > 0", {
 })
 
 test_that("longitudinal_fit raises warning for too few observations", {
-  set.seed(1)
   epileptic <- epileptic |> dplyr::filter(time < 368) |> head(20)
   epileptic <- epileptic[-c(18, 19), ]
 
+  withr::local_seed(123)
   x <- initialise_longitudinal_test_(epileptic = epileptic)
 
   expect_warning(
@@ -219,7 +220,7 @@ test_that("longitudinal_fit raises warning for too few observations", {
 })
 
 test_that("predict_longitudinal works correctly with lcmm", {
-  set.seed(1)
+  withr::local_seed(1)
 
   data("epileptic")
 

--- a/tests/testthat/test-landmarking_longitudinal.R
+++ b/tests/testthat/test-landmarking_longitudinal.R
@@ -1,7 +1,5 @@
 initialise_longitudinal_test_ <- function(epileptic, K = 1) {
-  set.seed(123)
   epileptic$dose2 <- as.factor(epileptic$dose > 2)
-
   epileptic_dfs <- split_wide_df(
     epileptic,
     ids = "id",

--- a/tests/testthat/test-landmarking_survival.R
+++ b/tests/testthat/test-landmarking_survival.R
@@ -1,6 +1,5 @@
 test_that("Error handling for fit_survival", {
-  set.seed(123)
-
+  withr::with_seed(123)
   epileptic_dfs <- split_wide_df(
     epileptic,
     ids = "id",

--- a/tests/testthat/test-landmarking_survival.R
+++ b/tests/testthat/test-landmarking_survival.R
@@ -1,5 +1,5 @@
 test_that("Error handling for fit_survival", {
-  withr::with_seed(123)
+  withr::local_seed(123)
   epileptic_dfs <- split_wide_df(
     epileptic,
     ids = "id",

--- a/tests/testthat/test_split_wide.R
+++ b/tests/testthat/test_split_wide.R
@@ -1,5 +1,5 @@
 test_that("split_wide_df works as expected", {
-  withr::with_seed(123)
+  withr::local_seed(123)
 
   static.correct <- c(
     "with.time",

--- a/tests/testthat/test_split_wide.R
+++ b/tests/testthat/test_split_wide.R
@@ -1,5 +1,5 @@
 test_that("split_wide_df works as expected", {
-  set.seed(123)
+  withr::with_seed(123)
 
   static.correct <- c(
     "with.time",


### PR DESCRIPTION
We have flaky tests that occur within the lcmm model fitting - likely due to within-test scope or due to parallelism. Using `{withr}` will hopefully fix that now. 